### PR TITLE
updated fc.check to use the single options argument

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,34 +7,41 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
-    foodcritic (2.1.0)
+    foodcritic (6.0.0)
       erubis
-      gherkin (~> 2.11.7)
-      nokogiri (~> 1.5.4)
-      rak (~> 1.4)
-      treetop (~> 1.4.10)
-      yajl-ruby (~> 1.1.0)
-    gherkin (2.11.8)
+      gherkin (~> 2.11)
+      nokogiri (>= 1.5, < 2.0)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
-    multi_json (1.7.7)
-    nokogiri (1.5.10)
-    polyglot (0.3.3)
-    rak (1.4)
-    rake (0.9.2.2)
-    rspec (2.14.0)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.2)
-    rspec-expectations (2.14.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.1)
-    treetop (1.4.14)
-      polyglot
-      polyglot (>= 0.3.1)
-    yajl-ruby (1.1.0)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    polyglot (0.3.5)
+    rake (10.5.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    rufus-lru (1.0.5)
+    treetop (1.6.3)
+      polyglot (~> 0.3)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -44,3 +51,6 @@ DEPENDENCIES
   lookout-foodcritic-rules!
   rake
   rspec
+
+BUNDLED WITH
+   1.10.6

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,12 @@ def foodcritic_run(rule_name)
   fc = FoodCritic::Linter.new
 
   opts = {
-    :include_rules => [File.join(PROJECT_ROOT, 'lib/foodcritic/rules')],
-    :tags => [rule_name.upcase]
+    include_rules: [File.join(PROJECT_ROOT, 'lib/foodcritic/rules')],
+    tags: [rule_name.upcase],
+    cookbook_paths: File.join(PROJECT_ROOT, 'sample_cookbooks', rule_name.downcase)
   }
 
-  cb_path = File.join(PROJECT_ROOT, 'sample_cookbooks', rule_name.downcase)
-
-  fc.check(cb_path, opts)
+  fc.check(opts)
 end
 
 def warnings(fc_run)


### PR DESCRIPTION
Your repo was the only one listed on [foodcritic.io][1] that actually had tests.  The [check method][2] has changed and the cookbooks path has moved in to the options.  Thought I would fix this in case anyone else comes looking.



[1]: http://www.foodcritic.io/#extra-rules
[2]: https://www.omniref.com/ruby/gems/foodcritic/4.0.0/symbols/FoodCritic::Linter/check?d=108886782&n=1#